### PR TITLE
fix: resolve postgres healthcheck failure

### DIFF
--- a/marzban-postgresql.yml
+++ b/marzban-postgresql.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - /var/lib/postgresql/marzban:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready -q -d ${DB_NAME} -U ${DB_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/marzban-postgresql.yml
+++ b/marzban-postgresql.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - /var/lib/postgresql/marzban:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD", "pg_isready" ]
+      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/marzban-timescaledb.yml
+++ b/marzban-timescaledb.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - /var/lib/postgresql/marzban:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
+      test: ["CMD-SHELL", "pg_isready -q -d ${DB_NAME} -U ${DB_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/marzban-timescaledb.yml
+++ b/marzban-timescaledb.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - /var/lib/postgresql/marzban:/var/lib/postgresql/data
     healthcheck:
-      test: [ "CMD", "pg_isready" ]
+      test: ["CMD-SHELL", "pg_isready -d ${DB_NAME} -U ${DB_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
### Purpose
the docker healthcheck does not include the postgreql user or database name. This causes errors such as the following:

``postgresql-1  | 2025-05-21 20:08:07.631 UTC [104] FATAL:  role "root" does not exist``

### Proposal
Update the ``pg_isready`` command to specify the username and password such as ``pg_isready -d $${DB_NAME} -U $${DB_USER}``.

See also:

- https://github.com/suitenumerique/docs/issues/731 for an example of this log message being reported. (however, it may not be the root cause of the issue described.)

- https://github.com/peter-evans/docker-compose-healthcheck/issues/16 for a similar report in another repo, fixed the same way