### PR TITLE
Fix: --name parsing for gozargah-node install

### DIFF
--- a/gozargah-node.sh
+++ b/gozargah-node.sh
@@ -498,6 +498,10 @@ install_command() {
             gozargah_node_version_set="true"
             shift
             ;;
+        --name)
+            # --name is handled globally; ignore here to prevent unknown option errors
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1"
             exit 1


### PR DESCRIPTION
## Summary
- handle `--name` flag in the `install` command's option parser so it no longer triggers an "Unknown option" error

## Testing
- `bash -n gozargah-node.sh`

------
https://chatgpt.com/codex/tasks/task_b_685afb473900832b80e6faadf55fb897